### PR TITLE
External mysql integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,13 @@ git repositories hosted by:
 - BitBucket
 
 Drone CI has a flexible job configuration via a single `.drone.yml` include in
-your repository. For more information, see the
-[upstream documentation](https://github.com/drone/drone/blob/v0.2.1/README.md#builds)
+your repository. For more information, see the [upstream documentation](https://github.com/drone/drone/blob/v0.2.1/README.md#builds)
 
 
 ## Getting Started with the DroneCI Charm
 
 DroneCI is deployable as a stand alone instance by default, leveraging SQLITE
-database, and no external dependnecies.
+database, and no external dependencies.
 
     juju deploy cs:trusty/drone-ci
 
@@ -37,36 +36,12 @@ via relation
     juju add-relation drone-ci:db mysql:db
 
 
-### Auth providers
-
-Drone requires an Authorization Provider in order to 'activate' itself. Drone
-fully integrates with the API's as a consumer leveraging the service you login
-from.
-
-#### Setting up GitHub
-
-Generate Client and Secret
-
-You must register your application with GitHub in order to generate a Client
-and Secret. Navigate to your account settings and choose Applications from the
-menu, and click [Register new application](https://github.com/settings/applications/new).
-
-Please use `/api/auth/github.com` as the Authorization callback URL path.
-
-![drone-ci github API setup](docs/img/github_setup.png)
-
-Once you have your application configured in GitHub, set these API credentials
-on the charm
-
-    juju set drone github_client=XXX github_secret=XXX github_enabled=true
-
 
 ## Known Issues / Caveats
 
-#### Auth Providers
-
-To begin, only GitHub is supported. Each auth provider will land shortly after
-the charm has stabilized, or interest in aforementioned provider is raised.
+#### Auth providers
+Drone currently supports several third party AUTH providers, which have not
+yet been added to the charm.
 
 #### Upstream Release Schedule / Compatibility
 Drone also iterates quickly, and has known to break backwords compatibility

--- a/hooks/db-relation-changed
+++ b/hooks/db-relation-changed
@@ -1,0 +1,1 @@
+hooks.py

--- a/playbooks/config-changed.yaml
+++ b/playbooks/config-changed.yaml
@@ -18,7 +18,8 @@
 
 - set_fact:
     appsecret: "{{session_token.stdout}}"
-  notify: "render drone template"
+  notify:
+      - drone config
 
 - name: Fetch Drone.
   get_url: url=http://downloads.drone.io/master/drone.deb dest=/tmp/drone.deb sha256sum={{drone_sum}}
@@ -28,9 +29,8 @@
   args:
      creates: /usr/local/bin/droned
 
-- name: render drone template
-  template: src=../templates/drone.toml dest=/etc/drone/drone.toml
-
+#- name: render drone template
+#  template: src=../templates/drone.toml dest=/etc/drone/drone.toml
 
 - name: Open port 80
   command: open-port 80

--- a/playbooks/db-relation-changed.yaml
+++ b/playbooks/db-relation-changed.yaml
@@ -1,0 +1,32 @@
+---
+
+- name: Receive relation data for private-address
+  shell: relation-get private-address
+  register: database_address
+
+- name: Receive relation data for database
+  shell: relation-get database
+  register: database_name
+
+- name: Receive relation data for username
+  shell: relation-get user
+  register: database_user
+
+- name: Receive relation data for  password
+  shell: relation-get password
+  register: database_password
+
+- name: Generate secret session token
+  command: pwgen -c -s -1 60
+  register: session_token
+
+- set_fact:
+    db_host: "{{database_address.stdout}}"
+    db_name: "{{database_name.stdout}}"
+    db_user: "{{database_user.stdout}}"
+    db_pass: "{{database_password.stdout}}"
+    mysql_enabled: 1
+    appsecret: "{{session_token.stdout}}"
+  notify:
+    - render config
+

--- a/playbooks/site.yaml
+++ b/playbooks/site.yaml
@@ -1,4 +1,7 @@
 - hosts: all
+  gather_facts: true
+  vars:
+      mysql_enabled: 0
   tasks:
     - include: config-changed.yaml
       tags:
@@ -14,3 +17,15 @@
       service: name=drone state=stopped
       tags:
         - stop
+
+    - name: External Database Configuration
+      include: db-relation-changed.yaml
+      tags:
+        - db-relation-changed
+
+    - name: render config
+      template: src=../templates/drone.toml dest=/etc/drone/drone.toml
+      tags:
+        - db-relation-changed
+        - config-changed
+

--- a/templates/drone.toml
+++ b/templates/drone.toml
@@ -5,6 +5,12 @@
   secret="{{appsecret}}"
   expires="72h"
 
+{% if mysql_enabled == 1 %}
+[database]
+driver = "mysql"
+datasource = "{{db_user}}:{{db_pass}}@tcp({{db_host}}:3306)/{{db_name}}"
+{% endif %}
+
 {% if github_enabled == True %}
 [github]
   client = "{{ github_client }}"

--- a/tests/20-external-database
+++ b/tests/20-external-database
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import amulet
+import requests
+import unittest
+
+
+class TestDeployment(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.deployment = amulet.Deployment(series='trusty')
+
+        cls.deployment.add('drone', 'local:trusty/drone')
+        cls.deployment.add('mysql', 'cs:trusty/mysql')
+        cls.deployment.relate('drone:db','mysql:db')
+        cls.deployment.expose('drone')
+
+        try:
+            cls.deployment.setup(timeout=900)
+            cls.deployment.sentry.wait()
+        except amulet.helpers.TimeoutError:
+            amulet.raise_status(amulet.SKIP, msg="Environment wasn't stood up in time")
+        except:
+            raise
+
+    def test_basic_standup(self):
+        '''
+        Assert we are indeed talking to the drone service. If 'drone' is not
+        discovered in the response body - we're not talking to drone and possibly
+        to a 503 error page, or something has gone terribly awry.
+        '''
+        pub = self.deployment.sentry['drone/0'].info['public-address']
+        response = requests.get("http://{}".format(pub))
+        response.raise_for_status()
+        response.raise_for_status
+        assert "drone" in response.text
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/mysql-formation.yaml
+++ b/tests/mysql-formation.yaml
@@ -1,0 +1,9 @@
+drone-with-mysql:
+  services:
+    "drone":
+        charm: local:trusty/drone
+        exposed: true
+    "mysql":
+        charm: cs:trusty/mysql
+  relations:
+    - ['drone:db', 'mysql:db']

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ commands =
     charm proof
     ansible-lint {toxinidir}/playbooks/site.yaml
     ansible-lint {toxinidir}/playbooks/config-changed.yaml
-
+    ansible-lint {toxinidir}/playbooks/db-relation-changed.yaml


### PR DESCRIPTION
@whitmo - this has a pretty gnarly bug without ansible caching the facts i'm setting. Do we have any way to persist these between runs? appsecret expiring, and database credentials nuking if you update config after the DB is related is pretty pitiful.
